### PR TITLE
Enable GPIO output

### DIFF
--- a/arch/risc-v/src/bl602/bl602_gpio.c
+++ b/arch/risc-v/src/bl602/bl602_gpio.c
@@ -129,6 +129,13 @@ int bl602_configgpio(gpio_pinset_t cfgset)
     }
 
   modifyreg32(regaddr, mask, cfg);
+
+  /* Enable pin output if requested */
+  if (!(cfgset & GPIO_INPUT))
+    {
+      modifyreg32(BL602_GPIO_CFGCTL34, 0, (1 << pin));
+    }
+
   return OK;
 }
 


### PR DESCRIPTION
## Summary

Configure BL602 GPIO Pins to enable output, if requested.

## Impact

Affects BL602 GPIO Output Pins.

## Testing

Tested on PineCone BL602 with GPIO Output connected to LED.