### PR TITLE
libc: Remove CONFIG_LIBC_ERR

### DIFF
--- a/include/err.h
+++ b/include/err.h
@@ -32,8 +32,6 @@
  * Public Function Prototypes
  ****************************************************************************/
 
-#ifdef CONFIG_LIBC_ERR
-
 /* Print "pid: ", FORMAT, ": ", the standard error string for errno,
  * and a newline, on stderr.
  */
@@ -53,5 +51,4 @@ void verr(int status, FAR const char *fmt, va_list ap) printflike(2, 0);
 void errx(int status, FAR const char *fmt, ...) printflike(2, 3);
 void verrx(int status, FAR const char *, va_list ap) printflike(2, 0);
 
-#endif /* CONFIG_LIBC_ERR */
 #endif /* __INCLUDE_ERR_H */

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -37,7 +37,7 @@ endif
 
 CSRCS += lib_dumpbuffer.c lib_dumpvbuffer.c lib_fnmatch.c lib_debug.c
 CSRCS += lib_crc64.c lib_crc32.c lib_crc16.c lib_crc8.c lib_crc8ccitt.c
-CSRCS += lib_crc8table.c lib_glob.c lib_execinfo.c lib_ftok.c
+CSRCS += lib_crc8table.c lib_glob.c lib_execinfo.c lib_ftok.c lib_err.c
 
 # Keyboard driver encoder/decoder
 
@@ -55,10 +55,6 @@ endif
 
 ifeq ($(CONFIG_LIBC_ENVPATH),y)
 CSRCS += lib_envpath.c
-endif
-
-ifeq ($(CONFIG_LIBC_ERR),y)
-CSRCS += lib_err.c
 endif
 
 # To ensure uname information is newest,


### PR DESCRIPTION
let linker remove the unused object files from the final image

Signed-off-by: Xiang Xiao <xiaoxiang@xiaomi.com>

